### PR TITLE
Grainy Decorator changes

### DIFF
--- a/src/fullctl/django/rest/decorators.py
+++ b/src/fullctl/django/rest/decorators.py
@@ -79,7 +79,6 @@ class grainy_endpoint:
         else:
             permissions_cls = RemotePermissions
 
-
         @grainy_rest_viewset_response(
             namespace=decorator.namespace,
             namespace_instance=decorator.namespace,
@@ -89,8 +88,6 @@ class grainy_endpoint:
             **decorator.kwargs,
         )
         def wrapped(self, request, *args, **kwargs):
-
-            request.org = Organization.objects.get(slug=request.nsparam["org_tag"])
 
             if decorator.require_auth and not request.user.is_authenticated:
                 return Response(status=401)

--- a/src/fullctl/django/rest/decorators.py
+++ b/src/fullctl/django/rest/decorators.py
@@ -2,14 +2,13 @@ from django.conf import settings
 
 from rest_framework import exceptions
 from rest_framework.response import Response
-from rest_framework import serializers
 
 import reversion
 
-from django_grainy.decorators import grainy_rest_viewset, grainy_rest_viewset_response
+from django_grainy.decorators import grainy_rest_viewset_response
 
 from fullctl.django.rest.core import HANDLEREF_FIELDS
-from fullctl.django.models import Organization, APIKey
+from fullctl.django.models import Organization
 
 
 from fullctl.django.auth import Permissions, RemotePermissions

--- a/src/fullctl/django/rest/decorators.py
+++ b/src/fullctl/django/rest/decorators.py
@@ -74,7 +74,11 @@ class grainy_endpoint:
     def __call__(self, fn):
         decorator = self
 
-        permissions_cls = RemotePermissions
+        if getattr(settings, "USE_LOCAL_PERMISSIONS", False):
+            permissions_cls = Permissions
+        else:
+            permissions_cls = RemotePermissions
+
 
         @grainy_rest_viewset_response(
             namespace=decorator.namespace,

--- a/src/fullctl/django/rest/views/account.py
+++ b/src/fullctl/django/rest/views/account.py
@@ -38,7 +38,8 @@ class Organization(viewsets.GenericViewSet):
 class User(viewsets.GenericViewSet):
 
     ref_tag = "user"
-
+    serializer_class = Serializers.asn
+    
     @action(detail=False, methods=["GET"])
     @grainy_endpoint()
     def asns(self, request, org, *args, **kwargs):


### PR DESCRIPTION
Makes some changes to the grainy_endpoint decorator uncovered while working on issue 32  in Ixctl:
https://github.com/fullctl/ixctl/issues/32

Closes https://github.com/fullctl/fullctl/issues/1

Changes:
- Add option for local permissions for testing, based on django settings
- Deletes an unnecessary line setting `request.org` since `request.org` should already be set by middleware
- Deletes unused imports

Another change on this branch is actually unrelated to the Grainy Decorator:
- Add a serializer class to the User view which is necessary to generate the openapi schema