### PR TITLE
peerctl network search fixes

### DIFF
--- a/src/fullctl/django/autocomplete/pdb.py
+++ b/src/fullctl/django/autocomplete/pdb.py
@@ -26,6 +26,12 @@ class peeringdb_asn(autocomplete.Select2QuerySetView):
         return item.asn
 
 
+class peeringdb_net(peeringdb_asn):
+    def get_queryset(self):
+        qs = list(pdbctl.Network().objects(q=self.q))
+        return qs
+
+
 class peeringdb_org(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         qs = pdbctl.Organization().objects(q=self.q)

--- a/src/fullctl/django/static/common/20c/twentyc.rest.js
+++ b/src/fullctl/django/static/common/20c/twentyc.rest.js
@@ -1592,7 +1592,7 @@ twentyc.rest.List = twentyc.cls.extend(
         response.rows(function(row, idx) {
           this.insert(row);
         }.bind(this));
-        $(this).trigger("load:after");
+        $(this).trigger("load:after", [response]);
         return
       }.bind(this));
     },

--- a/src/fullctl/django/static/common/app.css
+++ b/src/fullctl/django/static/common/app.css
@@ -504,10 +504,12 @@ div.toolbar-field input[type="text"] {
 .list-body .secondary select,
 div.toolbar-field select,
 div.toolbar input[type=text],
+.select2-container--default .select2-selection--single,
 div.toolbar select {
   border: none;
   border-radius: 0px;
 }
+.select2-container--default .select2-selection--single,
 div.toolbar select {
   font-size: 20px;
   font-weight: bold;
@@ -517,6 +519,11 @@ div.toolbar select {
   -moz-appearance: none;
   appearance: none;
   margin-left: 16px;
+}
+
+
+div.toolbar .select2-container .select2-selection--single {
+  height: 35px;
 }
 
 div.toolbar input[type=text] {

--- a/src/fullctl/django/static/common/themes/dark.css
+++ b/src/fullctl/django/static/common/themes/dark.css
@@ -227,9 +227,14 @@ div.toolbar-field input[type="text"]:disabled {
 }
 div.toolbar-field select,
 div.toolbar input[type=text],
+div.toolbar .select2-container--default .select2-selection--single,
 div.toolbar select {
   background-color: #3C4650;
   color: #fff;
+}
+
+div.toolbar .select2-container--default .select2-selection--single {
+  border-color: transparent;
 }
 
 div.toolbar-field,

--- a/src/fullctl/django/urls.py
+++ b/src/fullctl/django/urls.py
@@ -26,6 +26,11 @@ if getattr(settings, "PDBCTL_URL", None):
             name="pdb asn autocomplete",
         ),
         path(
+            "autocomplete/pdb/net",
+            fullctl.django.autocomplete.pdb.peeringdb_net.as_view(),
+            name="pdb asn autocomplete",
+        ),
+        path(
             "autocomplete/pdb/org",
             fullctl.django.autocomplete.pdb.peeringdb_org.as_view(),
             name="pdb org autocomplete",


### PR DESCRIPTION
- add pdbctl network search autocomplete
- some minor style updates to v1 theme for peerctl network search
- adds `response` parameter to `load:after` event on `twentyc.rest.List`

requires https://github.com/fullctl/pdbctl/pull/9 to be merged