### PR TITLE
fix: change on condition to enable swift deletion of task_schedule

### DIFF
--- a/docs/service_bridge.md
+++ b/docs/service_bridge.md
@@ -23,17 +23,13 @@ These can be used to push data from the model to its references, or pull in addi
 
 - **deviceCtl** pushing facility data and device locations to **nautobot**
 
-
-
-
 ### Overview of `client.py` (Service Bridge Client)
 
-The `client.py` module within the `fullctl` package provides a robust and flexible framework for interacting with different services via HTTP, particularly focusing on facilitating communication and data exchange with service bridges. 
+The `client.py` module within the `fullctl` package provides a robust and flexible framework for interacting with different services via HTTP, particularly focusing on facilitating communication and data exchange with service bridges.
 
 #### Key Components:
 
 - **Bridge Class:** Serves as the base class for creating service bridges. It handles the construction of HTTP requests, execution, and response parsing with features to support caching, authentication, and error handling. Key methods include `get`, `post`, `put`, `patch`, `delete`, for performing respective HTTP operations, and methods like `object`, `objects`, `create`, `destroy`, `update`, etc., for high-level operations on service entities.
-  
 - **ServiceBridgeError and AuthError Classes:** Custom exceptions to handle service bridge related errors and authentication errors specifically.
 
 - **Utility Functions:** Includes `trim_endpoint` and `url_join` for manipulating URL strings to ensure correct endpoint formatting.
@@ -43,6 +39,7 @@ The `client.py` module within the `fullctl` package provides a robust and flexib
 #### How to Use:
 
 To use the service bridge client, one would typically extend the `Bridge` class to create a service-specific client. For example, to create a client for a hypothetical service `Xyz`, one would:
+
 1. Define a subclass of `Bridge`, say `XyzBridge`.
 2. Possibly override `url_prefix`, `results_key`, and the inner `Meta` class attributes to suit the specifics of the `Xyz` service.
 3. Implement any additional methods if needed, or use the existing ones to interact with the `Xyz` service.
@@ -51,7 +48,7 @@ To use the service bridge client, one would typically extend the `Bridge` class 
 class XyzBridge(Bridge):
     url_prefix = "data"
     results_key = "results"
-    
+
     class Meta:
         service = "xyz"
         ref_tag = "xyz"
@@ -59,7 +56,6 @@ class XyzBridge(Bridge):
 ```
 
 Then, you can use this class to perform API operations against the `Xyz` service.
-
 
 ### Extra Information for the Nautobot Client (`nautobot.py`):
 
@@ -80,6 +76,7 @@ This setup greatly facilitates the development of services integrating with Naut
 ### Nautobot Service Bridge Usage Example
 
 #### Authentication
+
 Interactions with the Nautobot service via the service bridge utilize an internal service API key for authentication. This key is typically set automatically through application environment settings, emphasizing the distinction from directly using Nautobot API tokens. This abstraction allows for flexible integration patterns.
 
 #### Retrieving a List of Devices
@@ -111,7 +108,7 @@ custom_api_key = 'your_custom_service_api_key_here'
 try:
     # Initialize the client with a custom API key, if needed
     device_client = Device(key=custom_api_key, org='your_org_here')
-    
+
     # Retrieve the device object first
     device = device_client.object(device_id)
     # Update the device

--- a/src/fullctl/django/models/concrete/tasks.py
+++ b/src/fullctl/django/models/concrete/tasks.py
@@ -651,8 +651,11 @@ class Monitor(HandleRefModel):
     def delete(self, **kwargs):
         super().delete(**kwargs)
 
-        if self.task_schedule.id:
-            self.task_schedule.delete()
+        try:
+            if self.task_schedule.id:
+                self.task_schedule.delete()
+        except TaskSchedule.DoesNotExist:
+            pass
 
 
 @fullctl.django.tasks.register

--- a/src/fullctl/django/models/concrete/tasks.py
+++ b/src/fullctl/django/models/concrete/tasks.py
@@ -651,7 +651,7 @@ class Monitor(HandleRefModel):
     def delete(self, **kwargs):
         super().delete(**kwargs)
 
-        if self.task_schedule:
+        if self.task_schedule.id:
             self.task_schedule.delete()
 
 


### PR DESCRIPTION
This fix is to created because of the issue of self.task_schedule being deleted in the model delete() after being deleted from the prefixctl signal.py file.

**Without the fix:**
This check will pass as True and return an error, saying task_shedule with id as None can not be deleted(since it was already deleted, i beleive its id is set to None)

**With fix:**
Here, we check if the id of the task_schedule still exists, if it does, delete it, if it doesnt dont