### PR TITLE
include path prefix in viewset namespace to avoid collisions

### DIFF
--- a/src/fullctl/django/rest/route/service_bridge.py
+++ b/src/fullctl/django/rest/route/service_bridge.py
@@ -12,5 +12,7 @@ def route(viewset):
     path_prefix = getattr(viewset, "path_prefix", "")
     prefix = f"service-bridge{path_prefix}/{ref_tag}"
 
-    router.register(prefix, viewset, basename=f"service-bridge-{ref_tag}")
+    basename = prefix.replace("/", "-")
+
+    router.register(prefix, viewset, basename=basename)
     return viewset


### PR DESCRIPTION
fixes ImproperlyConfigured error raised by drf 3.15.1