### PR TITLE
Fc 3536 task error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - task queue auto requeue stuck tasks
 ### Fixed
 - select2 background color issue
+- task workers will now recover from hard failures
 ### Removed
 - py3.8 support
 - fullctl_sync_peeringdb (moved to pdbctl as pdbctl_sync_peeringdb)

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -4,6 +4,7 @@ Unreleased:
   - task queue auto requeue stuck tasks
   fixed:
   - select2 background color issue
+  - task workers will now recover from hard failures
   changed: []
   deprecated: []
   removed:

--- a/src/fullctl/django/management/commands/base.py
+++ b/src/fullctl/django/management/commands/base.py
@@ -64,6 +64,7 @@ class CommandInterface(BaseCommand):
 
     @auditlog()
     def handle(self, auditlog=None, *args, **kwargs):
+        self.error = None
         self.auditlog_context = auditlog
         self.output = []
         self.queue = kwargs.get("queue")
@@ -136,6 +137,7 @@ class CommandInterface(BaseCommand):
     def log_error(self, msg):
         self.log.error(msg)
         self.auditlog_context.append_data(error=f"{msg}")
+        self.error = msg
 
     def run(self, *args, **kwargs):
         raise NotImplementedError()

--- a/src/fullctl/django/management/commands/fullctl_poll_tasks.py
+++ b/src/fullctl/django/management/commands/fullctl_poll_tasks.py
@@ -1,7 +1,8 @@
 import asyncio
 import uuid
-
+import structlog
 import reversion
+import psycopg
 from asgiref.sync import sync_to_async
 
 from fullctl.django.management.commands.base import CommandInterface
@@ -12,6 +13,8 @@ from fullctl.django.tasks.orm import (
     progress_schedules,
     tasks_max_time_reached,
 )
+
+log = structlog.get_logger("django")
 
 
 class Worker:
@@ -115,48 +118,62 @@ class Command(CommandInterface):
 
     async def _process_workers(self):
         while True:
-            await asyncio.sleep(self.sleep_interval)
+            try:
+                await asyncio.sleep(self.sleep_interval)
 
-            for worker in self.workers:
-                await worker.work()
+                for worker in self.workers:
+                    await worker.work()
+            except Exception as exc:
+                log.exception("Error processing workers", exc=exc)
 
     async def _poll_tasks(self):
         while True:
-            await asyncio.sleep(self.poll_interval)
+            task = None
+            try:
+                await asyncio.sleep(self.poll_interval)
 
-            if not self.worker_available:
-                if not self.all_workers_busy:
-                    self.log_info("All workers busy")
-                    self.all_workers_busy = True
-                continue
-            else:
-                if self.all_workers_busy:
-                    self.log_info("Worker available")
-                self.all_workers_busy = False
+                if not self.worker_available:
+                    if not self.all_workers_busy:
+                        self.log_info("All workers busy")
+                        self.all_workers_busy = True
+                    continue
+                else:
+                    if self.all_workers_busy:
+                        self.log_info("Worker available")
+                    self.all_workers_busy = False
 
-            # check on stuck tasks and perform requeuing on those that have max times reached
-            await sync_to_async(tasks_max_time_reached)()
+                # check on stuck tasks and perform requeuing on those that have max times reached
+                await sync_to_async(tasks_max_time_reached)()
 
-            # django call needs to be wrapped in sync_to_async
+                # django call needs to be wrapped in sync_to_async
 
-            task = await sync_to_async(fetch_task)()
+                task = await sync_to_async(fetch_task)()
 
-            if not task or task.queue_id:
-                continue
+                if not task or task.queue_id:
+                    continue
 
-            self.log_info(f"New task {task}")
+                self.log_info(f"New task {task}")
 
-            # django call needs to be wrapped in sync_to_async
+                # django call needs to be wrapped in sync_to_async
 
-            await sync_to_async(self.claim_task)(task)
+                await sync_to_async(self.claim_task)(task)
 
-            await self.delegate_task(task)
+                await self.delegate_task(task)
+            except psycopg.OperationalError as exc:
+                log.exception("Error polling tasks (db error)", exc=exc)
+                await asyncio.sleep(3)
+            except Exception as exc:
+                log.exception("Error polling tasks", exc=exc)
+                await self.handle_task_setup_error(exc, task)
 
     async def _progress_schedules(self):
         while True:
-            await asyncio.sleep(self.poll_interval)
-            await sync_to_async(progress_schedules)()
-
+            try:
+                await asyncio.sleep(self.poll_interval)
+                await sync_to_async(progress_schedules)()
+            except Exception as exc:
+                log.exception("Error progressing schedules", exc=exc)
+            
     def claim_task(self, task):
         try:
             with reversion.create_revision():

--- a/src/fullctl/django/management/commands/fullctl_poll_tasks.py
+++ b/src/fullctl/django/management/commands/fullctl_poll_tasks.py
@@ -1,8 +1,9 @@
 import asyncio
 import uuid
-import structlog
-import reversion
+
 import psycopg
+import reversion
+import structlog
 from asgiref.sync import sync_to_async
 
 from fullctl.django.management.commands.base import CommandInterface
@@ -173,7 +174,7 @@ class Command(CommandInterface):
                 await sync_to_async(progress_schedules)()
             except Exception as exc:
                 log.exception("Error progressing schedules", exc=exc)
-            
+
     def claim_task(self, task):
         try:
             with reversion.create_revision():

--- a/src/fullctl/django/management/commands/fullctl_work_task.py
+++ b/src/fullctl/django/management/commands/fullctl_work_task.py
@@ -1,7 +1,12 @@
 from fullctl.django.management.commands.base import CommandInterface
 from fullctl.django.models import Task
-from fullctl.django.tasks.orm import specify_task, work_task
+from fullctl.django.tasks.orm import specify_task, work_task, set_task_as_failed
+import psycopg
+import structlog
+import time
+import traceback
 
+log = structlog.get_logger("django")
 
 class Command(CommandInterface):
     help = "Process the specified task"
@@ -12,17 +17,53 @@ class Command(CommandInterface):
         super().add_arguments(parser)
         parser.add_argument("task_id", nargs="?")
 
+    def handle(self, *args, **kwargs):
+        self.task_id = kwargs.get("task_id")
+        try:
+            super().handle(*args, **kwargs)
+
+            task = Task.objects.get(id=self.task_id)
+            if getattr(self, "error", None) and not task.error:
+                # failure, but wasn't within the context
+                # of the task execution logic, transfer error 
+                # to task
+                set_task_as_failed(task, self.error)
+
+            if task.error:
+                self.log_info("Task failed")
+                self.log_error(task.error)
+            else:
+                self.log_info("Task finished")
+
+        except Exception as exc:
+            log.exception("Error in task run", exc=exc)
+            self.handle_outer_error(exc)
+
     def run(self, *args, **kwargs):
         task_id = kwargs.get("task_id")
-
         task = specify_task(Task.objects.get(id=task_id))
-
         self.log_info(f"Processing {task}")
-
         work_task(task)
 
-        if task.error:
-            self.log_info("Task failed")
-            self.log_error(task.error)
-        else:
-            self.log_info("Task finished")
+    def handle_outer_error(self, exc:Exception, retries:int=5):
+
+        """
+        Handles errors that happen when setting up the task for processing
+
+        This catches issues such as temporary database failures.
+        """
+
+        try:
+            if isinstance(exc,psycopg.OperationalError):
+                # db issue, give time to recover
+                time.sleep(3)
+            task = specify_task(Task.objects.get(id= self.task_id))
+            # set task as failed
+            set_task_as_failed(task, traceback.format_exc())
+        except Exception as exc:
+            log.exception(f"Error in task run (error cleanup, retries={retries})", exc=exc)
+            if retries > 0:
+                self.handle_outer_error(exc, retries-1)
+                # if error is never recovered during retries
+                # task will end up orphaned as `pending` and will be eventually
+                # re-queued by the poller whenever the max age limit is hit.

--- a/src/fullctl/django/tasks/__init__.py
+++ b/src/fullctl/django/tasks/__init__.py
@@ -39,7 +39,6 @@ def create_tasks_from_json(config, parent=None, user=None, org=None, tasks=None)
 
     return tasks
 
-
 def requeue(generic_task):
     """
     Method to re-queue a task. This will create a new task with the same arguments.

--- a/src/fullctl/django/tasks/__init__.py
+++ b/src/fullctl/django/tasks/__init__.py
@@ -39,6 +39,7 @@ def create_tasks_from_json(config, parent=None, user=None, org=None, tasks=None)
 
     return tasks
 
+
 def requeue(generic_task):
     """
     Method to re-queue a task. This will create a new task with the same arguments.

--- a/src/fullctl/django/tasks/orm.py
+++ b/src/fullctl/django/tasks/orm.py
@@ -54,6 +54,16 @@ def fetch_task(**filters):
         return tasks[0]
     return None
 
+def set_task_as_failed(generic_task, error_message=None, requeue=False):
+    """
+    Set task to failed with error information and re-queue
+    """
+
+    generic_task.status = "failed"
+    generic_task.error = error_message
+    generic_task.save()
+    if requeue:
+        requeue_task(generic_task)
 
 def tasks_max_time_reached():
     """

--- a/src/fullctl/django/tasks/orm.py
+++ b/src/fullctl/django/tasks/orm.py
@@ -54,6 +54,7 @@ def fetch_task(**filters):
         return tasks[0]
     return None
 
+
 def set_task_as_failed(generic_task, error_message=None, requeue=False):
     """
     Set task to failed with error information and re-queue
@@ -64,6 +65,7 @@ def set_task_as_failed(generic_task, error_message=None, requeue=False):
     generic_task.save()
     if requeue:
         requeue_task(generic_task)
+
 
 def tasks_max_time_reached():
     """

--- a/tests/django_tests/test_commands.py
+++ b/tests/django_tests/test_commands.py
@@ -1,3 +1,6 @@
+# import magicmock
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core import management
@@ -6,12 +9,11 @@ import tests.django_tests.testapp.models as models
 from fullctl.django.models import Task
 from fullctl.django.tasks.orm import specify_task
 
-# import magicmock
-from unittest.mock import patch
 
 def test_fullctl_poll_tasks(db, dj_account_objects):
     with pytest.raises(SystemExit):
         management.call_command("fullctl_poll_tasks", "--help")
+
 
 def test_fullctl_promote_user(db, dj_account_objects_c):
     management.call_command("fullctl_promote_user", "user_test_c", "--commit")
@@ -30,6 +32,7 @@ def test_fullctl_work_task(db, dj_account_objects):
     assert task.status == "completed"
     assert int(task.output) == 3
 
+
 @patch("fullctl.django.management.commands.fullctl_work_task.Command.run")
 def test_fullctl_work_task_error_handling_in_run(mock_run, db, dj_account_objects):
     # test error handling of errors in `run` call
@@ -42,8 +45,11 @@ def test_fullctl_work_task_error_handling_in_run(mock_run, db, dj_account_object
     assert task.status == "failed"
     assert "Test exception" in task.error
 
+
 @patch("fullctl.django.management.commands.base.CommandInterface.handle")
-def test_fullctl_work_task_error_handling_in_handle(mock_handle, db, dj_account_objects):
+def test_fullctl_work_task_error_handling_in_handle(
+    mock_handle, db, dj_account_objects
+):
     # test error handling of errors in `handle` call
     task = models.TestTask.create_task(1, 2)
     mock_handle.side_effect = Exception("Test exception")
@@ -53,6 +59,7 @@ def test_fullctl_work_task_error_handling_in_handle(mock_handle, db, dj_account_
 
     assert task.status == "failed"
     assert "Test exception" in task.error
+
 
 def test_fullctl_work_task_fail(db, dj_account_objects):
     task = models.FailingTask.create_task()


### PR DESCRIPTION
- allows to recover during exceptions in the polling or task worker setups (such as teporary db failures)
- fixed issues where tasks wouldn't be marked as failed if errors happened outside of the task logic